### PR TITLE
make image publishable with automatic date-sha tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,12 @@ archeio:
 	go build -v -o "$(OUT_DIR)/$(ARCHEIO_BINARY_NAME)" $(ARCHEIO_BUILD_FLAGS) ./cmd/archeio
 # alias for building archeio
 build: archeio
-# build images
+# build images to local tarball
 images:
 	hack/make-rules/images.sh
+# push images
+push-images:
+	PUSH=true hack/make-rules/images.sh
 # build image for archeio
 archeio-image:
 	IMAGES=cmd/archeio hack/make-rules/images.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,11 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+steps:
+- name: gcr.io/cloud-builders/docker
+  entrypoint: /usr/bin/make
+  args:
+    - push-images
+    - TAG=$_GIT_TAG
+substitutions:
+  # variables set by kubernetes/test-infra/images/builder
+  # set by image-builder to vYYYYMMDD-hash
+  _GIT_TAG: "12345"


### PR DESCRIPTION
... using `make push-images`

will push `gcr.io/k8s-staging-infra-tools/archeio:v$date-$sha`

`make images` will build to a tarball under `bin/archeio.tar`