### PR TITLE
fixes for enabling CI

### DIFF
--- a/hack/make-rules/images.sh
+++ b/hack/make-rules/images.sh
@@ -40,7 +40,7 @@ cd "${REPO_ROOT}"
 
 # build images
 # TODO: bake commit info into binaries consistently
-for image in ${images[@]}; do
+for image in "${images[@]}"; do
     name="$(basename "${image}")"
     # push or local tarball
     publish_args=(--tarball=bin/"${name}".tar --push=false)

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -27,13 +27,13 @@ res=0
 
 if [[ "${VERIFY_LINT:-true}" == "true" ]]; then
   echo "verifying lints ..."
-  hack/make-rules/verify/lint.sh || res=1
+  hack/make-rules/lint.sh || res=1
   cd "${REPO_ROOT}"
 fi
 
 if [[ "${VERIFY_SHELLCHECK:-true}" == "true" ]]; then
   echo "verifying shellcheck ..."
-  hack/make-rules/verify/shellcheck.sh || res=1
+  hack/make-rules/shellcheck.sh || res=1
   cd "${REPO_ROOT}"
 fi
 

--- a/hack/tools/ci-install-shellcheck.sh
+++ b/hack/tools/ci-install-shellcheck.sh
@@ -26,18 +26,20 @@ cd "${REPO_ROOT}"
 # get version from shellcheck script
 scversion="v$(sed -nr 's/SHELLCHECK_VERSION="(.*)"/\1/p' hack/make-rules/shellcheck.sh)"
 echo "Installing shellcheck ${scversion} from upstream to ensure CI version ..."
+echo ""
 
 # install xz so we can untar the upstream release
 export DEBIAN_FRONTEND=noninteractive
-apt update
-apt install xz-utils
+apt-get -qq update
+DEBCONF_NOWARNINGS="yes" apt-get -qq install --no-install-recommends xz-utils >/dev/null
 
-# untar in tempdir
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "${tmp_dir:?}"' EXIT
-cd "${tmp_dir}"
-wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
-mv "shellcheck-${scversion}/shellcheck" /usr/bin/
+# download and untar shellcheck into /usr/bin
+wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" \
+  | tar -C /usr/bin --strip-components=1 -xJ -f - "shellcheck-${scversion}/shellcheck"
 
 # debug installed version
 shellcheck --version
+
+echo ""
+echo "Done installing shellcheck ..."
+echo ""

--- a/hack/tools/ci-install-shellcheck.sh
+++ b/hack/tools/ci-install-shellcheck.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# script to install shellcheck in CI
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# cd to repo root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &> /dev/null && pwd -P)"
+cd "${REPO_ROOT}"
+
+# get version from shellcheck script
+scversion="v$(sed -nr 's/SHELLCHECK_VERSION="(.*)"/\1/p' hack/make-rules/shellcheck.sh)"
+echo "Installing shellcheck ${scversion} from upstream to ensure CI version ..."
+
+# install xz so we can untar the upstream release
+export DEBIAN_FRONTEND=noninteractive
+apt update
+apt install xz-utils
+
+# untar in tempdir
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir:?}"' EXIT
+cd "${tmp_dir}"
+wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
+mv "shellcheck-${scversion}/shellcheck" /usr/bin/
+
+# debug installed version
+shellcheck --version


### PR DESCRIPTION
- fix paths in verify.sh after refactoring repo layout in previous PRs
- add a script to install shellcheck in CI matching the desired version used in the shellcheck script, so we can DRY that out and just use the golang image for all presubmits
- fix minor shellcheck error that slipped through because we don't have CI enabled yet

xref #7 