### PR TITLE
switch to klog, simplify for pure redirect iteration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module sigs.k8s.io/oci-proxy
 
 go 1.17
+
+require k8s.io/klog/v2 v2.40.1
+
+require github.com/go-logr/logr v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+k8s.io/klog/v2 v2.40.1 h1:P4RRucWk/lFOlDdkAr3mc7iWFkgKrZY9qZMAgek06S4=
+k8s.io/klog/v2 v2.40.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=


### PR DESCRIPTION
preparing for registry.k8s.io fqdn to serve *just* a redirect.
- drop unneeded logic for now
- switch logging to klog, move request logging to non-default log level (we're going to log a LOT of lines if we don't do this)