### PR TITLE
Add custom registries for e2e tests.

### DIFF
--- a/hack/images/default-sandbox.yaml
+++ b/hack/images/default-sandbox.yaml
@@ -1,0 +1,6 @@
+promoterE2eRegistry: registry-sandbox.k8s.io/e2e-test-images
+buildImageRegistry: registry-sandbox.k8s.io/build-image
+gcEtcdRegistry: registry-sandbox.k8s.io
+gcRegistry: registry-sandbox.k8s.io
+sigStorageRegistry: registry-sandbox.k8s.io/sig-storage
+cloudProviderGcpRegistry: registry-sandbox.k8s.io/cloud-provider-gcp


### PR DESCRIPTION
Make registry-sandbox.k8s.io the default registry for some e2e tests.
Signed-off-by: Arnaud Meukam <ameukam@gmail.com>