### PR TITLE
Revert "Remove shellcheck comment"

### DIFF
--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -29,7 +29,8 @@ REGIONS=(
     us-west1
 )
 
-for REGION in "${REGIONS[@]}"; do
+# shellcheck disable=SC2048
+for REGION in ${REGIONS[*]}; do
     gcloud --project="${PROJECT}" \
         run services update "${SERVICE_BASENAME}-${REGION}" \
         --image "${IMAGE_REPO}:${TAG}" \


### PR DESCRIPTION
Reverts kubernetes-sigs/oci-proxy#54.

Fixes splitting of `$REGIONS` into `us-central1`, `us-west1` instead of `us-central1 us-west1`