### PR TITLE
REVERT ME: debug why we're not redirecting kops to S3

### DIFF
--- a/cmd/archeio/app/handlers.go
+++ b/cmd/archeio/app/handlers.go
@@ -79,6 +79,10 @@ func makeV2Handler(upstreamRegistry string) func(w http.ResponseWriter, r *http.
 			return
 		}
 
+		// TODO: revert this!
+		// we just need some real data to debug
+		klog.InfoS("blob request client info", "clientIP", clientIP, "headers", r.Header, "path", path)
+
 		region, matched := regionMapper.GetIP(clientIP)
 		if !matched {
 			// no region match, redirect to main upstream registry


### PR DESCRIPTION
I suspect we should not stay in the business of logging client IPs even with few people having access.
But this should *only* be deployed to the sandbox instance, which is not advertised to end users, only CI, and something is up there. Need to get some real data to debug. https://github.com/kubernetes-sigs/oci-proxy/pull/60#issuecomment-1105771135