### PR TITLE
cache bucket HEAD requests

### DIFF
--- a/cmd/archeio/app/buckets_integration_test.go
+++ b/cmd/archeio/app/buckets_integration_test.go
@@ -23,42 +23,60 @@ import (
 	"testing"
 )
 
-func TestSimpleBlobChecker(t *testing.T) {
+func TestCachedBlobChecker(t *testing.T) {
 	bucket := awsRegionToS3URL("us-east-1")
-	blobs := &simpleBlobChecker{}
+	blobs := newCachedBlobChecker()
 	testCases := []struct {
 		Name         string
 		BlobURL      string
+		Bucket       string
 		HashKey      string
 		ExpectExists bool
 	}{
 		{
 			Name:         "known bucket entry",
 			BlobURL:      bucket + "/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
+			Bucket:       bucket,
 			HashKey:      "3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 			ExpectExists: true,
 		},
 		{
 			Name:         "known bucket, bad entry",
+			Bucket:       bucket,
 			BlobURL:      bucket + "/c0ntainers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 			ExpectExists: false,
 		},
 		{
 			Name:         "bogus bucket on domain without webserver",
+			Bucket:       "http://bogus.k8s.io/",
 			BlobURL:      "http://bogus.k8s.io/foo",
 			HashKey:      "b0guS",
 			ExpectExists: false,
 		},
 	}
+	// run test cases in parallel and then serial
+	// this populates the cache on the first run while doing parallel testing
+	// and allows us to check cached behavior on the second run
 	for i := range testCases {
 		tc := testCases[i]
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			url := tc.BlobURL
-			exists := blobs.BlobExists(url, tc.HashKey)
+			exists := blobs.BlobExists(url, tc.Bucket, tc.HashKey)
 			if exists != tc.ExpectExists {
 				t.Fatalf("expected: %v but got: %v", tc.ExpectExists, exists)
 			}
 		})
 	}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			url := tc.BlobURL
+			exists := blobs.BlobExists(url, tc.Bucket, tc.HashKey)
+			if exists != tc.ExpectExists {
+				t.Fatalf("expected: %v but got: %v", tc.ExpectExists, exists)
+			}
+		})
+	}
+
 }

--- a/cmd/archeio/app/handlers.go
+++ b/cmd/archeio/app/handlers.go
@@ -36,7 +36,7 @@ const (
 // upstream registry should be the url to the primary registry
 // archeio is fronting.
 func MakeHandler(upstreamRegistry string) http.Handler {
-	blobs := &simpleBlobChecker{}
+	blobs := newCachedBlobChecker()
 	doV2 := makeV2Handler(upstreamRegistry, blobs)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// all valid registry requests should be at /v2/
@@ -95,7 +95,7 @@ func makeV2Handler(upstreamRegistry string, blobs blobChecker) func(w http.Respo
 		hash := matches[1]
 		// this matches GCR's GCS layout, which we will use for other buckets
 		blobURL := bucketURL + "/containers/images/sha256%3A" + hash
-		if blobs.BlobExists(blobURL, hash) {
+		if blobs.BlobExists(blobURL, bucketURL, hash) {
 			// blob known to be available in S3, redirect client there
 			klog.V(2).InfoS("redirecting blob request to S3", "path", path)
 			http.Redirect(w, r, blobURL, http.StatusPermanentRedirect)

--- a/cmd/archeio/app/handlers_test.go
+++ b/cmd/archeio/app/handlers_test.go
@@ -95,7 +95,7 @@ type fakeBlobsChecker struct {
 	knownURLs map[string]bool
 }
 
-func (f *fakeBlobsChecker) BlobExists(blobURL, hashKey string) bool {
+func (f *fakeBlobsChecker) BlobExists(blobURL, bucket, hashKey string) bool {
 	return f.knownURLs[blobURL]
 }
 


### PR DESCRIPTION
follow up to #66 

NOTE: this is a very naive (but should be reasonably fast) cache with **no eviction**. This is fine because we've selected 10 buckets https://github.com/kubernetes-sigs/oci-proxy/issues/39#issuecomment-1085230292 and there are approximately 97,000 blobs, with hashes being 64 bytes we can cache in approximately 10 * 100,000 * 64 bytes AKA 64 MB *even if* we actually observe _all_ keys in _all_ buckets for the lifecycle of the container, which is not remotely likely (consider e.g. that requests should be routed to the nearest cloud run instance, in addition to number of containers being scaled up/down).