### PR TITLE
serve 200 OK for /v2/ API check

### DIFF
--- a/cmd/archeio/app/handlers_test.go
+++ b/cmd/archeio/app/handlers_test.go
@@ -46,8 +46,12 @@ func TestMakeHandler(t *testing.T) {
 		{
 			Name:           "/v2/",
 			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2/", nil),
-			ExpectedStatus: http.StatusPermanentRedirect,
-			ExpectedURL:    "https://k8s.gcr.io/v2/",
+			ExpectedStatus: http.StatusOK,
+		},
+		{
+			Name:           "/v2",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2", nil),
+			ExpectedStatus: http.StatusOK,
 		},
 		{
 			Name:           "/v2/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",


### PR DESCRIPTION
part of #77 

I think we could instead serve 401 and craft an appropriate `Www-Authenticate: Bearer realm` header that includes the scope (unlike GCR, which lets the client determine it based on the repo it parses in the image name), but that's more complex and unnecessary.

Our target use case involves publicly readable registries, and GCR public read is *really* public read, you don't need to present an auth token for any of the API calls.