### PR TITLE
Update AWS region to S3 url to use production buckets

### DIFF
--- a/cmd/archeio/app/buckets.go
+++ b/cmd/archeio/app/buckets.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 
@@ -28,6 +29,8 @@ import (
 // blobs in the buckets should be stored at /containers/images/sha256:$hash
 func awsRegionToS3URL(region string) string {
 	switch region {
+	case "us-west-1", "us-west-2", "us-east-1", "us-east-2", "eu-central-1", "ap-southeast-1", "ap-northeast-1", "ap-south-1":
+		return fmt.Sprintf("https://prod-registry-k8s-io-%v.s3.%v.amazonaws.com", region, region)
 	default:
 		return "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"
 	}

--- a/cmd/archeio/app/buckets.go
+++ b/cmd/archeio/app/buckets.go
@@ -29,7 +29,7 @@ import (
 // blobs in the buckets should be stored at /containers/images/sha256:$hash
 func awsRegionToS3URL(region string) string {
 	switch region {
-	case "us-west-1", "us-west-2", "us-east-1", "us-east-2", "eu-central-1", "ap-southeast-1", "ap-northeast-1", "ap-south-1":
+	case "us-west-1", "us-west-2", "us-east-1", "us-east-2", "eu-central-1", "eu-west-1", "ap-southeast-1", "ap-northeast-1", "ap-south-1":
 		return fmt.Sprintf("https://prod-registry-k8s-io-%v.s3.dualstack.%v.amazonaws.com", region, region)
 	default:
 		// default to us-east-2 for stability purposes

--- a/cmd/archeio/app/buckets.go
+++ b/cmd/archeio/app/buckets.go
@@ -30,8 +30,9 @@ import (
 func awsRegionToS3URL(region string) string {
 	switch region {
 	case "us-west-1", "us-west-2", "us-east-1", "us-east-2", "eu-central-1", "ap-southeast-1", "ap-northeast-1", "ap-south-1":
-		return fmt.Sprintf("https://prod-registry-k8s-io-%v.s3.%v.amazonaws.com", region, region)
+		return fmt.Sprintf("https://prod-registry-k8s-io-%v.s3.dualstack.%v.amazonaws.com", region, region)
 	default:
+		// default to us-east-2 for stability purposes
 		return "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"
 	}
 }

--- a/cmd/archeio/app/handlers_test.go
+++ b/cmd/archeio/app/handlers_test.go
@@ -113,7 +113,14 @@ func TestMakeV2Handler(t *testing.T) {
 	const upstreamRegistry = "https://k8s.gcr.io"
 	blobs := fakeBlobsChecker{
 		knownURLs: map[string]bool{
-			"https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e": true,
+			"https://prod-registry-k8s-io-ap-south-1.s3.dualstack.ap-south-1.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":         true,
+			"https://prod-registry-k8s-io-ap-southeast-1.s3.dualstack.ap-southeast-1.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e": true,
+			"https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":     true,
+			"https://prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
+			"https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
+			"https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
+			"https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
+			"https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
 		},
 	}
 	handler := makeV2Handler(upstreamRegistry, &blobs)


### PR DESCRIPTION
Once the buckets have been synced, use the production S3 bucket URLs

Depends on: https://github.com/cncf-infra/aws-infra/issues/4, https://github.com/kubernetes/k8s.io/issues/3623