### PR TITLE
Add endpoint to serve LF privacy page

### DIFF
--- a/cmd/archeio/app/handlers.go
+++ b/cmd/archeio/app/handlers.go
@@ -28,7 +28,8 @@ import (
 
 const (
 	// hard coded for now
-	infoURL = "https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io"
+	infoURL    = "https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io"
+	privacyURL = "https://www.linuxfoundation.org/privacy-policy/"
 )
 
 // MakeHandler returns the root archeio HTTP handler
@@ -49,6 +50,8 @@ func MakeHandler(upstreamRegistry string) http.Handler {
 			doV2(w, r)
 		case path == "/":
 			http.Redirect(w, r, infoURL, http.StatusTemporaryRedirect)
+		case strings.HasPrefix(path, "/privacy"):
+			http.Redirect(w, r, privacyURL, http.StatusTemporaryRedirect)
 		default:
 			klog.V(2).InfoS("unknown request", "path", path)
 			http.NotFound(w, r)

--- a/cmd/archeio/app/handlers_test.go
+++ b/cmd/archeio/app/handlers_test.go
@@ -39,6 +39,12 @@ func TestMakeHandler(t *testing.T) {
 			ExpectedURL:    infoURL,
 		},
 		{
+			Name:           "/privacy",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/privacy", nil),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    privacyURL,
+		},
+		{
 			Name:           "/v3/",
 			Request:        httptest.NewRequest("GET", "http://localhost:8080/v3/", nil),
 			ExpectedStatus: http.StatusNotFound,

--- a/cmd/archeio/docs/request-handling.md
+++ b/cmd/archeio/docs/request-handling.md
@@ -3,7 +3,8 @@
 Requests to archeio follows the following flow:
 
 1. If it's a request for `/`: redirect to our wiki page about the project
-2. If it's not a request for `/` and does not start with `/v2/`: 404 error
+2. If it's a request for `/privacy`: redirect to linux foundation privacy policy page
+2. If it's not a request for `/` or `/privacy` and does not start with `/v2/`: 404 error
 3. For registry API requests, all of which start with `/v2/`:
   - If it's not a blob request: redirect to Upstream Registry
   - If it's not a known AWS IP: redirect to Upstream Registry
@@ -17,7 +18,9 @@ Or in chart form:
 flowchart TD
 
 A(Does the request path start with /v2/?) -->|No, it is not a registry API call| B(Is the request for /?)
-B -->|No, it is an unknown path| D[Serve 404 error]
+B -->|No| D[Is the request for /privacy?]
+D -->|No, it is an unknown path| C[Serve 404 error]
+D -->|Yes| K[Serve redirect to linux foundation privacy policy page]
 B -->|Yes| E[Serve redirect to registry wiki page]
 A -->|Yes, it is a registry API call| F(Is it a blob request?)
 F -->|No| G[Serve redirect to Upstream Registry https://k8s.gcr.io]


### PR DESCRIPTION
Fixes #81 

## Proposed changes

- Add `/privacy` endpoint  to `handlers.go` to serve LF privacy policy page.
- Add new endpoint to test case in `handlers_test.go`.
- Update request-handling.md text and chart flow.