### PR TITLE
Use first ready production bucket

### DIFF
--- a/cmd/archeio/app/buckets.go
+++ b/cmd/archeio/app/buckets.go
@@ -27,10 +27,9 @@ import (
 //
 // blobs in the buckets should be stored at /containers/images/sha256:$hash
 func awsRegionToS3URL(region string) string {
-	// for now always return @ameukam's test bucket
 	switch region {
 	default:
-		return "https://painfully-really-suddenly-many-raccoon-image-layers.s3.us-west-2.amazonaws.com"
+		return "https://prod-registry-k8s-io-us-east-2.s3.us-west-2.amazonaws.com"
 	}
 }
 


### PR DESCRIPTION
Since as of `date` the bucket `s3://prod-registry-k8s-io-us-east-2` is synced, let's move https://registry-sandbox.k8s.io over to it, after the remaining 8(?) are copied over https://github.com/kubernetes-sigs/oci-proxy/pull/82 is ready to merge.